### PR TITLE
feat: apply data restrictions

### DIFF
--- a/src/__tests__/pic-definition.spec.js
+++ b/src/__tests__/pic-definition.spec.js
@@ -3,6 +3,7 @@ const mock = ({
   cells = () => [],
   spanLabels = () => [],
   tooltip = () => ['nope'],
+  disclaimer = () => [],
   scales = () => ({}),
   stack = () => ({}),
 } = {}) => aw.mock([
@@ -10,6 +11,7 @@ const mock = ({
   ['**/components/cells.js', () => cells],
   ['**/components/span-labels.js', () => spanLabels],
   ['**/components/tooltip.js', () => tooltip],
+  ['**/components/disclaimer.js', () => disclaimer],
   ['**/scales.js', () => scales],
   ['**/stack.js', () => stack],
 ], ['../pic-definition']);
@@ -49,6 +51,25 @@ describe('pic-definition', () => {
       });
       const c = def({ context: { permissions: ['passive'] } }).components;
       expect(c).to.eql(['t']);
+    });
+
+    it('should only contain disclaimer component when disruptive restrictions apply', () => {
+      const [{ default: def }] = mock({
+        disclaimer: () => ['d'],
+        cells: () => ['c'],
+      });
+      const c = def({ context, restricted: { type: 'disrupt' } });
+      expect(c).to.eql({
+        components: ['d'],
+      });
+    });
+
+    it('should contain disclaimer component when restrictions apply', () => {
+      const [{ default: def }] = mock({
+        disclaimer: () => ['d'],
+      });
+      const c = def({ context, restricted: {} }).components;
+      expect(c).to.eql(['d']);
     });
   });
 

--- a/src/component-definitions/disclaimer.js
+++ b/src/component-definitions/disclaimer.js
@@ -1,0 +1,80 @@
+function calculateState(c, settings) {
+  const struct = {
+    type: 'text',
+    text: settings.text,
+    x: 0,
+    y: 0,
+    dx: 0,
+    dy: 0,
+    anchor: 'left',
+    baseline: 'alphabetical',
+    ...c.style.text,
+  };
+
+  const textRect = c.renderer.measureText(struct);
+  const preferredSize = /px$/.test(c.style.text.lineHeight) ? parseInt(c.style.text.lineHeight, 10) : textRect.height;
+
+  return {
+    textRect,
+    struct,
+    preferredSize,
+  };
+}
+
+const component = {
+  require: ['renderer', 'chart'],
+  defaultSettings: {
+    layout: {
+      dock: 'bottom',
+      displayOrder: 0,
+      prioOrder: 0,
+    },
+    settings: {},
+    style: {
+      text: '$title',
+    },
+  },
+
+  created() {
+    this.state = calculateState(this, this.settings.settings);
+  },
+
+  beforeUpdate(opts) {
+    this.state = calculateState(this, opts.settings.settings);
+  },
+
+  preferredSize() {
+    return this.state.preferredSize;
+  },
+
+  render() {
+    const {
+      rect,
+      state,
+    } = this;
+
+    const { dock } = this.settings;
+
+    const struct = { ...state.struct };
+    struct.dy = -state.textRect.height / 6;
+
+    const padTop = (state.preferredSize - state.textRect.height) / 2;
+
+    struct.y = padTop + rect.height / 2 + state.textRect.height / 3;
+    struct.maxWidth = rect.width;
+
+    if (dock === 'center') {
+      struct.anchor = 'middle';
+      struct.x = rect.width / 2;
+    }
+
+    const nodes = [
+      struct,
+    ];
+    return nodes;
+  },
+};
+
+export default function plugin(picasso) {
+  picasso.component('disclaimer', component);
+}

--- a/src/components/disclaimer.js
+++ b/src/components/disclaimer.js
@@ -1,0 +1,34 @@
+export default function disclaimer(config) {
+  if (!config) {
+    return [];
+  }
+  // TODO - use translator
+  if (config.type === 'disrupt') {
+    return [{
+      key: 'disclaimer',
+      type: 'disclaimer',
+      dock: 'center',
+      settings: {
+        text: config.label,
+      },
+    }];
+  }
+
+  return [{
+    key: 'disclaimer',
+    type: 'disclaimer',
+    dock: 'bottom',
+    style: {
+      text: {
+        '@extend': '$label',
+        fontSize: '12px',
+        lineHeight: '16px',
+        fontStyle: 'italic',
+      },
+    },
+    settings: {
+      text: `* ${config.label}`,
+      anchor: 'left',
+    },
+  }];
+}

--- a/src/data-restrictions.js
+++ b/src/data-restrictions.js
@@ -1,0 +1,38 @@
+export const RESTRICTIONS = {
+  HasNoData: {
+    label: 'The selections generated no data for this chart.',
+    translation: 'NoDataExist',
+    type: 'disrupt',
+  },
+  HasOnlyNaNValues: {
+    label: 'The chart is not displayed because it contains only undefined values.',
+    translation: 'OnlyNaNData',
+    type: 'disrupt',
+  },
+  HasOnlyNegativeOrZeroValues: {
+    label: 'The chart is not displayed because it contains only negative or zero values.',
+    translation: 'OnlyNegativeOrZeroValues',
+    type: 'disrupt',
+  },
+  HasZeroOrNegativeValues: {
+    label: 'The data set contains negative or zero values that cannot be shown in this chart.',
+    translation: 'NegativeOrZeroValues',
+    type: 'note',
+  },
+};
+
+export function restriction(hc) {
+  if (hc.qSize.qcy <= 0) {
+    return RESTRICTIONS.HasNoData;
+  }
+  if (hc.qMeasureInfo[0].qMax === 'NaN') {
+    return RESTRICTIONS.HasOnlyNaNValues;
+  }
+  if (hc.qMeasureInfo[0].qMax <= 0) {
+    return RESTRICTIONS.HasOnlyNegativeOrZeroValues;
+  }
+  if (hc.qMeasureInfo[0].qMin <= 0) {
+    return RESTRICTIONS.HasZeroOrNegativeValues;
+  }
+  return undefined;
+}

--- a/src/pic-definition.js
+++ b/src/pic-definition.js
@@ -2,6 +2,7 @@ import axis from './components/axis';
 import cells from './components/cells';
 import spanLabels from './components/span-labels';
 import tooltip from './components/tooltip';
+import disclaimer from './components/disclaimer';
 
 import scales from './scales';
 import stack from './stack';
@@ -9,10 +10,17 @@ import stack from './stack';
 import REFS from './refs';
 
 export default function ({
-  layout, // eslint-disable-line no-unused-vars
+  // layout
   context,
   color,
+  restricted,
 }) {
+  if (restricted && restricted.type === 'disrupt') {
+    return {
+      components: disclaimer(restricted),
+    };
+  }
+
   const allowTooltip = context.permissions.indexOf('passive') !== -1;
   return {
     collections: [
@@ -31,6 +39,7 @@ export default function ({
       ...cells({ context, color }),
       ...spanLabels({ context }),
       ...(allowTooltip ? tooltip() : []),
+      ...disclaimer(restricted),
     ],
     interactions: [{
       type: 'native',


### PR DESCRIPTION
Mekko chart is not able to use negative or zero values in a good way, the user needs to be informed when the data contains such values. In addition, a disclaimer is shown in case a chart can't be rendered at all and why.

![Screenshot 2019-08-29 at 16 15 55](https://user-images.githubusercontent.com/16324367/63948560-2c9f4600-ca79-11e9-95e8-32a805aa9d4c.png)
