### PR TITLE
feat: add more info in tooltip

### DIFF
--- a/src/__tests__/pic-definition.spec.js
+++ b/src/__tests__/pic-definition.spec.js
@@ -26,6 +26,7 @@ describe('pic-definition', () => {
     scales: () => ({ colorScale: 's' }),
     palettes: () => ['p'],
     legend: () => ({ components: [], interactions: [] }),
+    settings: () => ({}),
   };
   const env = {};
   describe('components', () => {

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ import ext from './ext';
 import plugin from './component-definitions/disclaimer';
 
 import { restriction, RESTRICTIONS } from './data-restrictions';
+import REFS from './refs';
 
 import chartColorConfig from './coloring';
 
@@ -84,7 +85,7 @@ export default function supernova(env) {
         });
 
         this.picassoColoring.config({
-          key: 'ferj',
+          key: REFS.CELL_COLOR,
           source: 'qHyperCube',
           hc,
           chartColorModel: c,

--- a/src/pic-definition.js
+++ b/src/pic-definition.js
@@ -99,13 +99,20 @@ export default function ({
       ...scales(),
       ...picassoColoring.scales(),
     },
+    formatters: {
+      metric: {
+        data: {
+          field: 'qMeasureInfo/0',
+        },
+      },
+    },
     palettes: picassoColoring.palettes(),
     components: [
       ...leg.components,
       ...axis(),
       ...cells({ context, contraster, colorFill }),
       ...spanLabels({ context }),
-      ...(allowTooltip ? tooltip() : []),
+      ...(allowTooltip ? tooltip(picassoColoring.settings(), env) : []),
       ...disclaimer(restricted, env),
     ],
     interactions: [...leg.interactions, allowTooltip ? tooltipInteraction() : false].filter(Boolean),

--- a/src/refs.js
+++ b/src/refs.js
@@ -2,4 +2,5 @@ export default {
   SPAN_COLLECTION: 'span',
   CELL_COLLECTION: 'cells',
   SERIES: 'series',
+  CELL_COLOR: 'ferj',
 };

--- a/test/integration/interaction.spec.js
+++ b/test/integration/interaction.spec.js
@@ -27,17 +27,17 @@ describe('interaction', () => {
     await page.waitForSelector('.pic-tooltip', { visible: true });
     let tooltipContent = [];
     let tooltiphHeader = await page.$eval('.pic-tooltip-content th', header => header.textContent);
-    let tooltipValue = await page.$eval('.pic-tooltip-content tr', value => value.textContent);
+    let tooltipValue = await page.$$eval('.pic-tooltip-content tr', values => values.map(v => v.textContent));
     tooltipContent.push(tooltiphHeader, tooltipValue);
-    expect(tooltipContent).to.eql(['Europe', '=1:3']);
+    expect(tooltipContent).to.eql(['Europe', ['Share:14.29%', '=1:3']]);
     // hover "Americas, 2012"
     tooltipContent = [];
     const rects = await page.$$('[data-key="cells"] rect[data-label="2012"]');
     await rects[1].hover();
     await page.waitForSelector('.pic-tooltip', { visible: true });
     tooltiphHeader = await page.$eval('.pic-tooltip-content th', header => header.textContent);
-    tooltipValue = await page.$eval('.pic-tooltip-content tr', value => value.textContent);
+    tooltipValue = await page.$$eval('.pic-tooltip-content tr', values => values.map(v => v.textContent));
     tooltipContent.push(tooltiphHeader, tooltipValue);
-    expect(tooltipContent).to.eql(['Americas, 2012', '=1:33.33%']);
+    expect(tooltipContent).to.eql(['Americas, 2012', ['Share:33.33%', '=1:1', 'Fiscal Year:2012']]);
   });
 });


### PR DESCRIPTION
Adds more info in the tooltip:

- Measure as absolute value
- Uses `Share` label to indicate share valie
- Color

![tooltip](https://user-images.githubusercontent.com/16324367/65329641-2e13e800-dbb9-11e9-9ed3-9621261078b2.png)
