### PR TITLE
chore: api compliance version fetch from git/cci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,6 +73,18 @@ jobs:
       - attach_workspace:
           at: ~/project
       - run:
+          name: Create version.txt
+          command: |
+            set -x
+            if [ -n "${CIRCLE_TAG}" ]; then
+              version=${CIRCLE_TAG#v}
+            else
+              version=$(git describe --tags --abbrev=7 --match "v*")
+              version=${version#v}
+            fi
+            echo "$version" > ./version.txt
+            echo "Building $version"
+      - run:
           name: Prepare API Compliance
           command: |
             docker pull ghcr.io/qlik-download/api-compliance
@@ -82,7 +94,7 @@ jobs:
       - run:
           name: Run API Compliance
           command: >
-            VER=v$(cat ./package.json | jq -r '.version')
+            VER=v$(cat ./version.txt')
 
             docker run --volumes-from specs
             -e SPEC_PATHS="6fb76a59-8ce3-4170-a739-e3a02d303602@/specs/properties.json"


### PR DESCRIPTION
Fetching the version from circle ci gives api compliance information about release status, which helps avoid future issues.