### PR TITLE
feat: enabled styling panel

### DIFF
--- a/src/ext.js
+++ b/src/ext.js
@@ -1,4 +1,5 @@
 import coloring from './coloring';
+import getStylingPanelDefinition from './styling-panel-definition';
 
 const addons = {
   type: 'items',
@@ -91,7 +92,8 @@ export default function ext(env) {
     }
     return [];
   };
-
+  const stylingPanelEnabled = env.flags.isEnabled('SENSECLIENT_IM_2022_STYLINGPANEL_MEKKOCHART');
+  const bkgOptionsEnabled = env.flags.isEnabled('SENSECLIENT_IM_2022_MEKKO_BG');
   const colorByDimension = {
     ref: 'cellColor.byDimension.typeValue',
     schemaIgnore: true,
@@ -131,6 +133,14 @@ export default function ext(env) {
         settings: {
           uses: 'settings',
           items: {
+            presentation: stylingPanelEnabled && {
+              type: 'items',
+              translation: 'properties.presentation',
+              grouped: true,
+              items: {
+                styleEditor: getStylingPanelDefinition(bkgOptionsEnabled),
+              },
+            },
             colorsAndLegend: {
               type: 'items',
               translation: 'properties.colorsAndLegend',

--- a/src/styling-panel-definition.js
+++ b/src/styling-panel-definition.js
@@ -1,0 +1,11 @@
+const getStylingPanelDefinition = (bkgOptionsEnabled) => ({
+  component: 'styling-panel',
+  chartTitle: 'Object.MekkoChart',
+  translation: 'LayerStyleEditor.component.styling',
+  subtitle: 'LayerStyleEditor.component.styling',
+  ref: 'components',
+  useGeneral: true,
+  useBackground: bkgOptionsEnabled,
+});
+
+export default getStylingPanelDefinition;


### PR DESCRIPTION
This PR is to enable the new styling panel (SENSECLIENT_IM_2022_STYLINGPANEL_MEKKOCHART) with background options (SENSECLIENT_IM_2022_MEKKO_BG) in the mekko chart