### PR TITLE
feat: add legend styling

### DIFF
--- a/src/__tests__/pic-definition.spec.js
+++ b/src/__tests__/pic-definition.spec.js
@@ -39,6 +39,9 @@ describe('pic-definition', () => {
     flags: {
       isEnabled: () => true,
     },
+    theme: {
+      getStyle: () => {},
+    },
   };
   describe('components', () => {
     it('should contain axis', () => {
@@ -191,6 +194,9 @@ describe('pic-definition', () => {
       layout: {},
       flags: {
         isEnabled: () => true,
+      },
+      theme: {
+        getStyle: () => {},
       },
     }).interactions;
     expect(c).to.eql(['legint']);

--- a/src/__tests__/styling-utils.spec.js
+++ b/src/__tests__/styling-utils.spec.js
@@ -1,0 +1,96 @@
+import {
+  getAxisLabelStyle,
+  getLegendLabelStyle,
+  getLegendTitleStyle,
+  getValueLabelStyle,
+  labelStylingDefinition,
+} from '../styling-utils';
+
+describe('Label styling definition', () => {
+  const path = 'example.path';
+  const chartId = 'mekkochart';
+  const mockFontResolver = {
+    getOptions: () => {
+      ['font1', 'font2', 'font3'];
+    },
+    getDefaultValue: () => {
+      'defaultValue';
+    },
+  };
+  const mockTheme = {
+    getStyle: () => {
+      'green';
+    },
+  };
+  const definition = labelStylingDefinition(path, mockFontResolver, chartId, mockTheme);
+
+  expect(definition.fontFamilyItem.ref).equal('example.path.fontFamily');
+  expect(definition.fontWrapperItem.items.fontSizeItem.ref).equal('example.path.fontSize');
+  expect(definition.fontWrapperItem.items.fontColorItem.ref).equal('example.path.fontColor');
+});
+
+describe('Styling options', () => {
+  let theme;
+  let layout;
+  let flags;
+
+  beforeEach(() => {
+    flags = {
+      isEnabled: () => true,
+    };
+    layout = {};
+    theme = {
+      getStyle: () => {},
+    };
+  });
+
+  it('should get corrext getAxisLabelStyle', () => {
+    const component = {
+      key: 'axis',
+      axis: {
+        label: { name: { fontFamily: 'aLabelFont, sans-serif', fontSize: '2000', fontColor: { color: 'green' } } },
+      },
+    };
+    layout.components = [component];
+    const style = getAxisLabelStyle(theme, layout, flags);
+    expect(style.fontFamily).eql('aLabelFont, sans-serif');
+    expect(style.fontSize).eql('2000');
+    expect(style.fill).eql('green');
+  });
+
+  it('should get corrext getValueLabelStyle', () => {
+    const component = {
+      key: 'value',
+      label: { value: { fontFamily: 'vLabelFont, sans-serif', fontSize: '3000', fontColor: { color: 'blue' } } },
+    };
+    layout.components = [component];
+    const style = getValueLabelStyle(theme, layout, flags);
+    expect(style.fontFamily).eql('vLabelFont, sans-serif');
+    expect(style.fontSize).eql(3000);
+    expect(style.fill).eql('blue');
+  });
+
+  it('should get corrext getLegendTitleStyle', () => {
+    const component = {
+      key: 'legend',
+      legend: { title: { fontFamily: 'lTitleFont, sans-serif', fontSize: '4000', fontColor: { color: 'purple' } } },
+    };
+    layout.components = [component];
+    const style = getLegendTitleStyle(theme, layout, flags);
+    expect(style.fontFamily).eql('lTitleFont, sans-serif');
+    expect(style.fontSize).eql('4000');
+    expect(style.color).eql('purple');
+  });
+
+  it('should get corrext getLegendLabelStyle', () => {
+    const component = {
+      key: 'legend',
+      legend: { label: { fontFamily: 'lLabelFont, sans-serif', fontSize: '5000', fontColor: { color: 'yellow' } } },
+    };
+    layout.components = [component];
+    const style = getLegendLabelStyle(theme, layout, flags);
+    expect(style.fontFamily).eql('lLabelFont, sans-serif');
+    expect(style.fontSize).eql('5000');
+    expect(style.color).eql('yellow');
+  });
+});

--- a/src/__tests__/styling-utils.spec.js
+++ b/src/__tests__/styling-utils.spec.js
@@ -7,26 +7,28 @@ import {
 } from '../styling-utils';
 
 describe('Label styling definition', () => {
-  const path = 'example.path';
-  const chartId = 'mekkochart';
-  const mockFontResolver = {
-    getOptions: () => {
-      ['font1', 'font2', 'font3'];
-    },
-    getDefaultValue: () => {
-      'defaultValue';
-    },
-  };
-  const mockTheme = {
-    getStyle: () => {
-      'green';
-    },
-  };
-  const definition = labelStylingDefinition(path, mockFontResolver, chartId, mockTheme);
+  it('should get correct label styling definition refs', () => {
+    const path = 'example.path';
+    const chartId = 'mekkochart';
+    const mockFontResolver = {
+      getOptions: () => {
+        ['font1', 'font2', 'font3'];
+      },
+      getDefaultValue: () => {
+        'defaultValue';
+      },
+    };
+    const mockTheme = {
+      getStyle: () => {
+        'green';
+      },
+    };
+    const definition = labelStylingDefinition(path, mockFontResolver, chartId, mockTheme);
 
-  expect(definition.fontFamilyItem.ref).equal('example.path.fontFamily');
-  expect(definition.fontWrapperItem.items.fontSizeItem.ref).equal('example.path.fontSize');
-  expect(definition.fontWrapperItem.items.fontColorItem.ref).equal('example.path.fontColor');
+    expect(definition.fontFamilyItem.ref).equal('example.path.fontFamily');
+    expect(definition.fontWrapperItem.items.fontSizeItem.ref).equal('example.path.fontSize');
+    expect(definition.fontWrapperItem.items.fontColorItem.ref).equal('example.path.fontColor');
+  });
 });
 
 describe('Styling options', () => {

--- a/src/coloring/picasso/index.js
+++ b/src/coloring/picasso/index.js
@@ -153,7 +153,7 @@ export default function coloringFn(resources) {
      * @param {string} [cfg.styleReference='object.legend']
      * @returns {object}
      */
-    legend({ eventName, key } = {}) {
+    legend({ eventName, key, styleOptions } = {}) {
       return legend(
         {
           eventName,
@@ -162,6 +162,7 @@ export default function coloringFn(resources) {
         {
           legendConfig: chartColorModel.getLegendSettings(),
           scaleKey: inputCache.key,
+          styleOptions,
           coloring: getSettings(),
           hc: inputCache.hc,
           scales: this.scales(),

--- a/src/coloring/picasso/legend/visual.js
+++ b/src/coloring/picasso/legend/visual.js
@@ -14,7 +14,7 @@ export const legendShow = (legendProps, hc, coloring) => {
 export function catLegend(componentConfig, opts) {
   const { key } = componentConfig;
 
-  const { scaleKey, scales, coloring, hc, constraints } = opts;
+  const { scaleKey, scales, coloring, hc, constraints, styleOptions } = opts;
 
   const s = `${scaleKey}Legend`;
 
@@ -30,12 +30,20 @@ export function catLegend(componentConfig, opts) {
     settings: {
       item: {
         show: (d) => d.datum.value !== -2,
+        label: {
+          fontSize: styleOptions.label.fontSize,
+          fontFamily: styleOptions.label.fontFamily,
+          fill: styleOptions.label.color,
+        },
       },
       title: {
         wordBreak: 'break-word',
         maxLines: 2,
         text: coloring.label || '',
         show: opts.legendConfig.showTitle !== false,
+        fontSize: styleOptions.title.fontSize,
+        fontFamily: styleOptions.title.fontFamily,
+        fill: styleOptions.title.color,
       },
       navigation: {
         disabled: constraints.active,

--- a/src/components/__tests__/axis.spec.js
+++ b/src/components/__tests__/axis.spec.js
@@ -1,38 +1,22 @@
 import axis from '../axis';
 
 describe('axis', () => {
-  const layout = {
-    components: [
-      {
-        key: 'axis',
-        axis: {
-          label: {
-            name: {
-              fontFamily: 'MyFontFamily',
-              fontSize: '12px',
-              fontColor: {
-                color: 'black',
-              },
-            },
-          },
-        },
-      },
-    ],
-  };
-  const flags = {
-    isEnabled: () => true,
+  const axisLabelStyle = {
+    fontSize: '12px',
+    fontFamily: 'MyFontFamily',
+    fill: 'black',
   };
 
   it('should not have valueLabelStyle on when layout does not have components', () => {
-    const a = axis({}, flags);
+    const a = axis({});
     const yAxis = a.find((x) => x.key === 'y-axis');
-    expect(yAxis.settings).to.eql(undefined);
+    expect(yAxis.settings.labels).to.eql({});
     const xAxis = a.find((x) => x.key === 'x-axis');
-    expect(xAxis.settings).to.eql(undefined);
+    expect(xAxis.settings.labels).to.eql({});
   });
 
   it('should have valueLabelStyle on y-axis', () => {
-    const a = axis(layout, flags);
+    const a = axis(axisLabelStyle);
     const yAxis = a.find((x) => x.key === 'y-axis');
     expect(yAxis.settings.labels.fontFamily).to.eql('MyFontFamily');
     expect(yAxis.settings.labels.fontSize).to.eql('12px');
@@ -40,7 +24,7 @@ describe('axis', () => {
   });
 
   it('should have valueLabelStyle on x-axis', () => {
-    const a = axis(layout, flags);
+    const a = axis(axisLabelStyle);
     const xAxis = a.find((x) => x.key === 'x-axis');
     expect(xAxis.settings.labels.fontFamily).to.eql('MyFontFamily');
     expect(xAxis.settings.labels.fontSize).to.eql('12px');

--- a/src/components/axis.js
+++ b/src/components/axis.js
@@ -1,21 +1,4 @@
-export default function axis(layout, flags, theme) {
-  const axisComponent = flags.isEnabled('CLIENT_IM_2022')
-    ? (layout.components || []).find((c) => c.key === 'axis')
-    : {};
-  const labelStyle =
-    axisComponent && axisComponent.axis && axisComponent.axis.label && axisComponent.axis.label.name
-      ? {
-          settings: {
-            labels: {
-              fontSize: axisComponent.axis.label.name.fontSize,
-              fontFamily: axisComponent.axis.label.name.fontFamily,
-              fill: axisComponent.axis.label.name.fontColor
-                ? axisComponent.axis.label.name.fontColor.color
-                : theme.getStyle('object', 'axis.label', 'color'),
-            },
-          },
-        }
-      : {};
+export default function axis(axisLabelStyle) {
   return [
     {
       key: 'y-axis',
@@ -29,7 +12,9 @@ export default function axis(layout, flags, theme) {
         type: 'd3-number',
         format: '.0%',
       },
-      ...labelStyle,
+      settings: {
+        labels: axisLabelStyle,
+      },
     },
     {
       key: 'x-axis',
@@ -43,7 +28,9 @@ export default function axis(layout, flags, theme) {
         type: 'd3-number',
         format: '.0%',
       },
-      ...labelStyle,
+      settings: {
+        labels: axisLabelStyle,
+      },
     },
   ];
 }

--- a/src/ext.js
+++ b/src/ext.js
@@ -95,14 +95,13 @@ export default function ext(env) {
   };
   const stylingPanelEnabled = env.flags.isEnabled('SENSECLIENT_IM_2022_STYLINGPANEL_MEKKOCHART');
   const bkgOptionsEnabled = env.flags.isEnabled('SENSECLIENT_IM_2022_MEKKO_BG');
-  const chartStylingEnabled = env.flags.isEnabled('CLIENT_IM_2022');
   const chartId = 'object.mekkochart';
   const fontResolver = createFontResolver({
     theme: env.sense.theme,
     translator,
     config: {
       id: chartId,
-      paths: ['axis.label.name', 'label.value'],
+      paths: ['axis.label.name', 'label.value', 'legend.title', 'legend.label'],
     },
   });
   const colorByDimension = {
@@ -151,7 +150,7 @@ export default function ext(env) {
               items: {
                 styleEditor: getStylingPanelDefinition(
                   bkgOptionsEnabled,
-                  chartStylingEnabled,
+                  env.flags,
                   env.sense.theme,
                   fontResolver,
                   chartId

--- a/src/pic-definition.js
+++ b/src/pic-definition.js
@@ -8,6 +8,7 @@ import scales from './scales';
 import stack from './stack';
 
 import REFS from './refs';
+import { getAxisLabelStyle, getLegendLabelStyle, getLegendTitleStyle, getValueLabelStyle } from './styling-utils';
 
 function tooltipInteraction() {
   return {
@@ -76,20 +77,14 @@ export default function picDefinition({
   const leg = picassoColoring.legend({
     key: 'color-legend',
     eventName: 'ev',
+    styleOptions: {
+      title: getLegendTitleStyle(theme, layout, flags),
+      label: getLegendLabelStyle(theme, layout, flags),
+    },
   });
-
+  const axisLabelStyle = getAxisLabelStyle(theme, layout, flags);
+  const valueLabelStyle = getValueLabelStyle(theme, layout, flags);
   const allowTooltip = !constraints.passive;
-  const valueLabel = flags.isEnabled('CLIENT_IM_2022') ? (layout.components || []).find((c) => c.key === 'value') : {};
-  const valueLabelStyle =
-    valueLabel && valueLabel.label && valueLabel.label.value
-      ? {
-          fontFamily: valueLabel.label.value.fontFamily,
-          fontSize: parseFloat(valueLabel.label.value.fontSize),
-          fill: valueLabel.label.value.fontColor
-            ? valueLabel.label.value.fontColor.color
-            : theme.getStyle('object', 'label.value', 'color'),
-        }
-      : {};
   return {
     strategy: {
       layoutModes: {
@@ -132,7 +127,7 @@ export default function picDefinition({
     palettes: picassoColoring.palettes(),
     components: [
       ...leg.components,
-      ...axis(layout, flags, theme),
+      ...axis(axisLabelStyle),
       ...cells({
         constraints,
         contraster,

--- a/src/styling-panel-definition.js
+++ b/src/styling-panel-definition.js
@@ -1,4 +1,69 @@
-const getStylingPanelDefinition = (bkgOptionsEnabled, chartStylingEnabled, theme, fontResolver, chartId) => ({
+import { labelStylingDefinition } from './styling-utils';
+
+const getStylingItems = (flags, theme, fontResolver, chartId) => {
+  const items = {};
+
+  if (flags.isEnabled('CLIENT_IM_2022')) {
+    items.axisLabelSection = {
+      translation: 'properties.axis.label',
+      component: 'panel-section',
+      items: {
+        labelSection: {
+          component: 'items',
+          ref: 'components',
+          key: 'axis',
+          items: labelStylingDefinition('axis.label.name', fontResolver, chartId, theme),
+        },
+      },
+    };
+
+    items.valueLabelSection = {
+      translation: 'properties.value.label',
+      component: 'panel-section',
+      items: {
+        labelSection: {
+          component: 'items',
+          ref: 'components',
+          key: 'value',
+          items: labelStylingDefinition('label.value', fontResolver, chartId, theme),
+        },
+      },
+    };
+  }
+
+  if (flags.isEnabled('CLIENT_IM_3051')) {
+    items.legendTitleSection = {
+      translation: 'properties.legend.title',
+      component: 'panel-section',
+      items: {
+        labelSection: {
+          component: 'items',
+          ref: 'components',
+          key: 'legend',
+          items: labelStylingDefinition('legend.title', fontResolver, chartId, theme),
+        },
+      },
+    };
+
+    items.legendLabelSection = {
+      translation: 'properties.legend.label',
+      component: 'panel-section',
+      items: {
+        labelSection: {
+          component: 'items',
+          ref: 'components',
+          key: 'legend',
+          items: labelStylingDefinition('legend.label', fontResolver, chartId, theme),
+        },
+      },
+    };
+  }
+
+  // returning undefined if nothing is enabled so that the styling panel is invisible in such a case
+  return Object.keys(items).length > 0 ? items : undefined;
+};
+
+const getStylingPanelDefinition = (bkgOptionsEnabled, flags, theme, fontResolver, chartId) => ({
   component: 'styling-panel',
   chartTitle: 'Object.MekkoChart',
   translation: 'LayerStyleEditor.component.styling',
@@ -6,94 +71,7 @@ const getStylingPanelDefinition = (bkgOptionsEnabled, chartStylingEnabled, theme
   ref: 'components',
   useGeneral: true,
   useBackground: bkgOptionsEnabled,
-  items: chartStylingEnabled
-    ? {
-        axisLabelSection: {
-          translation: 'properties.axis.label',
-          component: 'panel-section',
-          items: {
-            labelSection: {
-              component: 'items',
-              ref: 'components',
-              key: 'axis',
-              items: {
-                fontFamily: {
-                  ref: 'axis.label.name.fontFamily',
-                  component: 'dropdown',
-                  options: () => fontResolver.getOptions('axis.label.name.fontFamily'),
-                  defaultValue: () => fontResolver.getDefaultValue('axis.label.name.fontFamily'),
-                },
-                fontWrapper: {
-                  component: 'inline-wrapper',
-                  items: {
-                    fontSize: {
-                      ref: 'axis.label.name.fontSize',
-                      component: 'dropdown',
-                      width: true,
-                      options: () => fontResolver.getOptions('axis.label.name.fontSize'),
-                      defaultValue: () => fontResolver.getDefaultValue('axis.label.name.fontSize'),
-                    },
-                    fontColor: {
-                      ref: 'axis.label.name.fontColor',
-                      component: 'color-picker',
-                      width: false,
-                      defaultValue: () => {
-                        const color = theme.getStyle(chartId, 'axis.label.name.color', 'color');
-                        const palette = theme.getDataColorPickerPalettes()[0].colors;
-                        const index = palette.indexOf(color);
-                        return { color, index };
-                      },
-                    },
-                  },
-                },
-              },
-            },
-          },
-        },
-        valueLabelSection: {
-          translation: 'properties.value.label',
-          component: 'panel-section',
-          items: {
-            labelSection: {
-              component: 'items',
-              ref: 'components',
-              key: 'value',
-              items: {
-                fontFamily: {
-                  ref: 'label.value.fontFamily',
-                  component: 'dropdown',
-                  options: () => fontResolver.getOptions('label.value.fontFamily'),
-                  defaultValue: () => fontResolver.getDefaultValue('label.value.fontFamily'),
-                },
-                fontWrapper: {
-                  component: 'inline-wrapper',
-                  items: {
-                    fontSize: {
-                      ref: 'label.value.fontSize',
-                      component: 'dropdown',
-                      width: true,
-                      options: () => fontResolver.getOptions('label.value.fontSize'),
-                      defaultValue: () => fontResolver.getDefaultValue('label.value.fontSize'),
-                    },
-                    fontColor: {
-                      ref: 'label.value.fontColor',
-                      component: 'color-picker',
-                      width: false,
-                      defaultValue: () => {
-                        const color = theme.getStyle(chartId, 'label.value.color', 'color');
-                        const palette = theme.getDataColorPickerPalettes()[0].colors;
-                        const index = palette.indexOf(color);
-                        return { color, index };
-                      },
-                    },
-                  },
-                },
-              },
-            },
-          },
-        },
-      }
-    : undefined,
+  items: getStylingItems(flags, theme, fontResolver, chartId),
 });
 
 export default getStylingPanelDefinition;

--- a/src/styling-utils.js
+++ b/src/styling-utils.js
@@ -1,0 +1,92 @@
+/**
+ * Get a property definiton containing settings for Font Family, Font Size and Color
+ * @param {string} path
+ * @param {object} fontResolver
+ * @param {string} chartId
+ * @param {object} theme
+ * @returns {object} property definition object
+ */
+export const labelStylingDefinition = (path, fontResolver, chartId, theme) => {
+  const pathFontFamily = `${path}.fontFamily`;
+  const pathFontSize = `${path}.fontSize`;
+
+  return {
+    fontFamilyItem: {
+      component: 'dropdown',
+      ref: pathFontFamily,
+      options: () => fontResolver.getOptions(pathFontFamily),
+      defaultValue: () => fontResolver.getDefaultValue(pathFontFamily),
+    },
+    fontWrapperItem: {
+      component: 'inline-wrapper',
+      items: {
+        fontSizeItem: {
+          component: 'dropdown',
+          ref: pathFontSize,
+          options: () => fontResolver.getOptions(pathFontSize),
+          defaultValue: () => fontResolver.getDefaultValue(pathFontSize),
+        },
+        fontColorItem: {
+          component: 'color-picker',
+          width: false,
+          ref: `${path}.fontColor`,
+          defaultValue: () => ({
+            color: theme.getStyle(chartId, path, 'color'),
+          }),
+        },
+      },
+    },
+  };
+};
+
+export const getAxisLabelStyle = (theme, layout, flags) => {
+  const axis = flags.isEnabled('CLIENT_IM_2022') ? (layout.components || []).find((c) => c.key === 'axis') : {};
+  return axis && axis.axis && axis.axis.label && axis.axis.label.name
+    ? {
+        fontSize: axis.axis.label.name.fontSize,
+        fontFamily: axis.axis.label.name.fontFamily,
+        fill: axis.axis.label.name.fontColor
+          ? axis.axis.label.name.fontColor.color
+          : theme.getStyle('object', 'axis.label', 'color'),
+      }
+    : {};
+};
+
+export const getValueLabelStyle = (theme, layout, flags) => {
+  const valueLabel = flags.isEnabled('CLIENT_IM_2022') ? (layout.components || []).find((c) => c.key === 'value') : {};
+  return valueLabel && valueLabel.label && valueLabel.label.value
+    ? {
+        fontFamily: valueLabel.label.value.fontFamily,
+        fontSize: parseFloat(valueLabel.label.value.fontSize),
+        fill: valueLabel.label.value.fontColor
+          ? valueLabel.label.value.fontColor.color
+          : theme.getStyle('object', 'label.value', 'color'),
+      }
+    : {};
+};
+
+export const getLegendTitleStyle = (theme, layout, flags) => {
+  const legend = flags.isEnabled('CLIENT_IM_3051') ? (layout.components || []).find((c) => c.key === 'legend') : {};
+  const title = legend && legend.legend && legend.legend.title;
+  const style = {
+    fontFamily: (title && title.fontFamily) || theme.getStyle('object', 'legend.title', 'fontFamily'),
+    fontSize: (title && title.fontSize) || theme.getStyle('object', 'legend.title', 'fontSize'),
+    color: (title && title.fontColor && title.fontColor.color) || theme.getStyle('object', 'legend.title', 'color'),
+  };
+
+  return style;
+};
+
+export const getLegendLabelStyle = (theme, layout, flags) => {
+  const legend = flags.isEnabled('CLIENT_IM_3051') ? (layout.components || []).find((c) => c.key === 'legend') : {};
+  const label = legend && legend.legend && legend.legend.label;
+  const style = {
+    fontFamily: (label && label.fontFamily) || theme.getStyle('object', 'legend.label', 'fontFamily'),
+    fontSize: (label && label.fontSize) || theme.getStyle('object', 'legend.label', 'fontSize'),
+    color: (label && label.fontColor && label.fontColor.color) || theme.getStyle('object', 'legend.label', 'color'),
+  };
+
+  return style;
+};
+
+export default { labelStylingDefinition };


### PR DESCRIPTION
## Description

Adding the possibility to configure styling for the following properties for the mekko legend

- Legend title
- Legend labels

Flag is CLIENT_IM_3051

Properties added to the components array:
```
{
  "key": "legend",
  "legend": {
    "title": {
      "fontFamily": "Courier, monospace",
      "fontSize": "24px",
      "color": { "index": -1, "color": "#ff5300" }
    },
    "label": {
      "fontFamily": "Didot, serif",
      "fontSize": "24px",
      "color": { "index": -1, "color": "#00ff0e" }
    }
  }
}
```
