### PR TITLE
chore: offboard styling ffs

### DIFF
--- a/src/__tests__/styling-utils.spec.js
+++ b/src/__tests__/styling-utils.spec.js
@@ -60,7 +60,7 @@ describe("Styling options", () => {
       },
     };
     layout.components = [component];
-    const style = getAxisLabelStyle(theme, layout, flags);
+    const style = getAxisLabelStyle(theme, layout);
     expect(style.fontFamily).toEqual("aLabelFont, sans-serif");
     expect(style.fontSize).toEqual("2000");
     expect(style.fill).toEqual("green");
@@ -78,7 +78,7 @@ describe("Styling options", () => {
       },
     };
     layout.components = [component];
-    const style = getValueLabelStyle(theme, layout, flags);
+    const style = getValueLabelStyle(theme, layout);
     expect(style.fontFamily).toEqual("vLabelFont, sans-serif");
     expect(style.fontSize).toEqual(3000);
     expect(style.fill).toEqual("blue");

--- a/src/ext.js
+++ b/src/ext.js
@@ -93,9 +93,6 @@ export default function ext(env) {
     }
     return [];
   };
-  const stylingPanelEnabled = flags.isEnabled("SENSECLIENT_IM_2022_STYLINGPANEL_MEKKOCHART");
-  const bkgOptionsEnabled = flags.isEnabled("SENSECLIENT_IM_2022_MEKKO_BG");
-
   const chartId = "object.mekkochart";
   const fontResolver = createFontResolver({
     theme: env.sense?.theme,
@@ -145,18 +142,12 @@ export default function ext(env) {
         settings: {
           uses: "settings",
           items: {
-            presentation: stylingPanelEnabled && {
+            presentation: {
               type: "items",
               translation: "properties.presentation",
               grouped: true,
               items: {
-                styleEditor: getStylingPanelDefinition(
-                  bkgOptionsEnabled,
-                  env.flags,
-                  env.sense.theme,
-                  fontResolver,
-                  chartId,
-                ),
+                styleEditor: getStylingPanelDefinition(env.flags, env.sense.theme, fontResolver, chartId),
               },
             },
             colorsAndLegend: {

--- a/src/pic-definition.js
+++ b/src/pic-definition.js
@@ -86,8 +86,8 @@ export default function picDefinition({
       label: getLegendLabelStyle(theme, layout, flags),
     },
   });
-  const axisLabelStyle = getAxisLabelStyle(theme, layout, flags);
-  const valueLabelStyle = getValueLabelStyle(theme, layout, flags);
+  const axisLabelStyle = getAxisLabelStyle(theme, layout);
+  const valueLabelStyle = getValueLabelStyle(theme, layout);
   const allowTooltip = !constraints.passive;
 
   return {

--- a/src/styling-panel-definition.js
+++ b/src/styling-panel-definition.js
@@ -3,33 +3,31 @@ import { labelStylingDefinition } from "./styling-utils";
 const getStylingItems = (flags, theme, fontResolver, chartId) => {
   const items = {};
 
-  if (flags.isEnabled("CLIENT_IM_2022")) {
-    items.axisLabelSection = {
-      translation: "properties.axis.label",
-      component: "panel-section",
-      items: {
-        labelSection: {
-          component: "items",
-          ref: "components",
-          key: "axis",
-          items: labelStylingDefinition("axis.label.name", fontResolver, chartId, theme),
-        },
+  items.axisLabelSection = {
+    translation: "properties.axis.label",
+    component: "panel-section",
+    items: {
+      labelSection: {
+        component: "items",
+        ref: "components",
+        key: "axis",
+        items: labelStylingDefinition("axis.label.name", fontResolver, chartId, theme),
       },
-    };
+    },
+  };
 
-    items.valueLabelSection = {
-      translation: "properties.value.label",
-      component: "panel-section",
-      items: {
-        labelSection: {
-          component: "items",
-          ref: "components",
-          key: "value",
-          items: labelStylingDefinition("label.value", fontResolver, chartId, theme),
-        },
+  items.valueLabelSection = {
+    translation: "properties.value.label",
+    component: "panel-section",
+    items: {
+      labelSection: {
+        component: "items",
+        ref: "components",
+        key: "value",
+        items: labelStylingDefinition("label.value", fontResolver, chartId, theme),
       },
-    };
-  }
+    },
+  };
 
   if (flags.isEnabled("CLIENT_IM_3051")) {
     items.legendTitleSection = {
@@ -63,14 +61,14 @@ const getStylingItems = (flags, theme, fontResolver, chartId) => {
   return Object.keys(items).length > 0 ? items : undefined;
 };
 
-const getStylingPanelDefinition = (bkgOptionsEnabled, flags, theme, fontResolver, chartId) => ({
+const getStylingPanelDefinition = (flags, theme, fontResolver, chartId) => ({
   component: "styling-panel",
   chartTitle: "Object.MekkoChart",
   translation: "LayerStyleEditor.component.styling",
   subtitle: "LayerStyleEditor.component.styling",
   ref: "components",
   useGeneral: true,
-  useBackground: bkgOptionsEnabled,
+  useBackground: true,
   items: getStylingItems(flags, theme, fontResolver, chartId),
 });
 

--- a/src/styling-utils.js
+++ b/src/styling-utils.js
@@ -39,8 +39,8 @@ export const labelStylingDefinition = (path, fontResolver, chartId, theme) => {
   };
 };
 
-export const getAxisLabelStyle = (theme, layout, flags) => {
-  const axis = flags.isEnabled("CLIENT_IM_2022") ? (layout.components || []).find((c) => c.key === "axis") : {};
+export const getAxisLabelStyle = (theme, layout) => {
+  const axis = (layout.components || []).find((c) => c.key === "axis");
   return axis && axis.axis && axis.axis.label && axis.axis.label.name
     ? {
         fontSize: axis.axis.label.name.fontSize,
@@ -52,8 +52,8 @@ export const getAxisLabelStyle = (theme, layout, flags) => {
     : {};
 };
 
-export const getValueLabelStyle = (theme, layout, flags) => {
-  const valueLabel = flags.isEnabled("CLIENT_IM_2022") ? (layout.components || []).find((c) => c.key === "value") : {};
+export const getValueLabelStyle = (theme, layout) => {
+  const valueLabel = (layout.components || []).find((c) => c.key === "value");
   return valueLabel && valueLabel.label && valueLabel.label.value
     ? {
         fontFamily: valueLabel.label.value.fontFamily,


### PR DESCRIPTION
Offboard styling FFs for sn-mekko-chart.
The following FFs have been offboarded.

- **SENSECLIENT_IM_2022_MEKKO_BG** - Jira: https://jira.qlikdev.com/browse/IM-4415
- **SENSECLIENT_IM_2022_STYLINGPANEL_MEKKOCHART** - Jira: https://jira.qlikdev.com/browse/IM-4414
- **CLIENT_IM_2022** - Jira: https://jira.qlikdev.com/browse/IM-4413